### PR TITLE
JSON-LD structured data for events

### DIFF
--- a/src/components/document/HeadMeta.astro
+++ b/src/components/document/HeadMeta.astro
@@ -11,9 +11,10 @@ interface Props {
     title: string;
     seo: SEOBlock;
     og: OGBlock;
+    structuredData?: Record<string, any>; // add structured data for JSON-LD
 }
 
-const { title, seo, og } = Astro.props;
+const { title, seo, og, structuredData } = Astro.props;
 
 const siteSettings = await getEntry('settings', 'siteSettingsPourdavoud');
 
@@ -75,3 +76,12 @@ const url = Astro.url;
     type="image/png"
 />
 <link href="/pourdavoud-favicon.svg" rel="shortcut icon" />
+{
+    structuredData && (
+        <script
+            is:inline
+            set:html={JSON.stringify(structuredData)}
+            type="application/ld+json"
+        />
+    )
+}

--- a/src/components/document/PageWrapper.astro
+++ b/src/components/document/PageWrapper.astro
@@ -15,6 +15,7 @@ interface Props {
     footerMargin?: boolean | null;
     seo?: SEOBlock;
     og?: OGBlock;
+    structuredData?: Record<string, any>;
     filterType?:
         | 'category'
         | 'event'
@@ -32,11 +33,12 @@ const {
     footerMargin = false,
     seo,
     og,
+    structuredData,
     filterType = 'page',
 } = Astro.props;
 ---
 
-<BaseLayout og={og} seo={seo} title={title}>
+<BaseLayout og={og} seo={seo} structuredData={structuredData} title={title}>
     <main
         class:list={['page', { 'footer-margin': footerMargin }]}
         data-filterType={filterType}

--- a/src/content/events.ts
+++ b/src/content/events.ts
@@ -47,6 +47,19 @@ export const events = defineCollection({
                 slug: z.string(),
             }),
         ),
+        place: z.array(
+            z.object({
+                name: z.string(),
+                location: z.object({
+                    streetAddress: z.string(),
+                    extendedAddress: z.string().nullish(),
+                    addressLocality: z.string(),
+                    addressRegion: z.string(),
+                    postalCode: z.string(),
+                    addressCountry: z.string(),
+                }),
+            }),
+        ),
         videos: z.array(z.object({ _id: z.string() })),
         categories: z.array(
             z.object({

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,9 +15,10 @@ interface Props {
     title: string;
     seo: SEOBlock;
     og: OGBlock;
+    structuredData?: Record<string, any>;
 }
 
-const { title, seo, og } = Astro.props;
+const { title, seo, og, structuredData } = Astro.props;
 ---
 
 <!doctype html>
@@ -25,7 +26,12 @@ const { title, seo, og } = Astro.props;
     <head>
         <meta charset="UTF-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-        <HeadMeta og={og} seo={seo} title={title} />
+        <HeadMeta
+            og={og}
+            seo={seo}
+            structuredData={structuredData}
+            title={title}
+        />
         <HeadAssets />
     </head>
     <body>

--- a/src/lib/sanity/queries/eventsQuery.ts
+++ b/src/lib/sanity/queries/eventsQuery.ts
@@ -35,6 +35,20 @@ export const EVENTS_QUERY = groq`*[_type == "event" && $workspaceID in workspace
         },
         []
     ),
+    "place": coalesce(
+        placeRef[] {
+            name,
+            location-> {
+                streetAddress,
+                extendedAddress,
+                addressLocality,
+                addressRegion,
+                postalCode,
+                addressCountry,
+            },
+        },
+        []
+    ),
     "videos": *[_type == "video" && references(^._id) && $workspaceID in workspaces[]._ref] {
         _id,
     },

--- a/src/lib/utils/jsonLD.ts
+++ b/src/lib/utils/jsonLD.ts
@@ -1,0 +1,85 @@
+import { type CollectionEntry } from 'astro:content';
+import { urlForImage } from '@lib/sanity/urlForImage';
+
+export const eventStructuredData = (
+    event: CollectionEntry<'events'>,
+): Record<string, any> => {
+    let image = undefined;
+    if (event.data.image) {
+        image = urlForImage(event.data.image)
+            .auto('format')
+            .fit('crop')
+            .crop('focalpoint');
+    }
+
+    // already checked for length
+    const place = event.data.place[0];
+
+    const schema: Record<string, any> = {
+        '@context': 'https://schema.org',
+        '@type': 'Event', // required
+        name: event.data.title, // required
+        startDate: event.data.details.startDate, // required
+        // endDate: '', // recommended if multi-day
+        eventStatus: 'https://schema.org/EventScheduled', // recommended
+        location: {
+            '@type': 'Place',
+            name: place.name, // recommended
+            address: {
+                '@type': 'PostalAddress',
+                extendedAddress: place.location.extendedAddress ?? '',
+                streetAddress: place.location.streetAddress,
+                addressLocality: place.location.addressLocality,
+                addressRegion: place.location.addressRegion,
+                postalCode: place.location.postalCode,
+                addressCountry: place.location.addressCountry,
+            }, // required
+        }, // required
+        // image: [], // recommended
+        // description: '', // recommended
+        organizer: {
+            '@type': 'Organization',
+            name: 'UCLA Pourdavoud Institute',
+            url: 'https://pourdavoud.ucla.edu',
+        }, // recommended
+    };
+
+    // add image set
+    if (image) {
+        schema.image = [
+            // image.width(1200).height(1200).url(), // 1x1
+            image.width(1200).height(900).url(), // 4x3
+            image.width(1200).height(675).url(), // 16x9
+        ];
+    }
+
+    // add description
+    if (event.data.preview?.length) {
+        if (event.data.preview[0].children.length) {
+            schema.description = event.data.preview[0].children[0].text;
+        }
+    }
+
+    // add times to dates
+    // if start time exists, append to start date
+    if (event.data.details.startTime) {
+        // leave off utc offset bc of standard vs dst? let google fill in
+        schema.startDate = `${event.data.details.startDate}T${event.data.details.startTime}:00`;
+    }
+
+    // if end time exists, assume same end date as start date and append end time
+    // else assume same end date as start date
+    if (event.data.details.endTime) {
+        schema.endDate = `${event.data.details.startDate}T${event.data.details.endTime}:00`;
+    } else {
+        schema.endDate = event.data.details.startDate;
+    }
+
+    // if multiday, overwrite both start/end dates with just dates, no time
+    if (event.data.details.multiDay) {
+        schema.startDate = event.data.details.startDate;
+        schema.endDate = event.data.details.endDate;
+    }
+
+    return schema;
+};

--- a/src/pages/[...event].astro
+++ b/src/pages/[...event].astro
@@ -7,6 +7,7 @@ import SanityImage from '@components/SanityImage.astro';
 import ShareLinks from '@components/interactive/ShareLinks.tsx';
 import SpeakerBio from '@components/people/SpeakerBio.astro';
 import SpeakerPreview from '@components/people/SpeakerPreview.astro';
+import { eventStructuredData } from '@lib/utils/jsonLD';
 import { formatEventDetails } from '@lib/utils/formatEvent';
 import { getCollection } from 'astro:content';
 import { isUpcoming } from '@lib/utils/isUpcoming';
@@ -54,6 +55,9 @@ if (event.data.tags.length > 0) {
     filterType="event"
     footerMargin={true}
     id={event.id}
+    structuredData={event.data.place.length > 0
+        ? eventStructuredData(event)
+        : undefined}
     template="eventsShow"
     title={event.data.previewTitle ?? event.data.title}
 >


### PR DESCRIPTION
Resolves #4 by adding JSON-LD structured data for the `events` content type.

- Expands GROQ query and content schema for `events` with new `place` reference
- Generates structured data (in page `head` script) for `events` with a physical place
- Passes [rich results validation](https://search.google.com/test/rich-results)